### PR TITLE
Update masking function

### DIFF
--- a/notebooks/ewoc_presto.py
+++ b/notebooks/ewoc_presto.py
@@ -1,17 +1,129 @@
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Optional
+from random import choice, randint, random, sample
+from typing import Any, List, Optional, Tuple
+
 import numpy as np
 import pandas as pd
 import torch
-from torch.utils.data import DataLoader, Dataset
+from torch.utils.data import Dataset
 
 import presto
-from presto.dataops import MaskParams
-from presto.dataops.masking import MaskedExample
+from presto.dataops.masking import (
+    BAND_EXPANSION,
+    BANDS_GROUPS_IDX,
+    MASK_STRATEGIES,
+    NUM_TIMESTEPS,
+    SRTM_INDEX,
+    TIMESTEPS_IDX,
+    MaskedExample,
+)
+
+
+def make_mask_no_dw(strategy: str, mask_ratio: float) -> np.ndarray:
+    """
+    Make a mask for a given strategy and percentage of masked values.
+    Args:
+        strategy: The masking strategy to use. One of MASK_STRATEGIES
+        mask_ratio: The percentage of values to mask. Between 0 and 1.
+    """
+
+    # SRTM is included here, but ignored by Presto
+    mask = np.full((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX)), False)
+    srtm_mask = False
+    num_tokens_to_mask = int(((NUM_TIMESTEPS * (len(BANDS_GROUPS_IDX) - 1)) + 1) * mask_ratio)
+
+    def mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio):
+        should_flip = random() < mask_ratio
+        if should_flip:
+            srtm_mask = True
+            num_tokens_to_mask -= 1
+        return srtm_mask, num_tokens_to_mask
+
+    def random_masking(mask, num_tokens_to_mask: int):
+        if num_tokens_to_mask > 0:
+            # we set SRTM to be True - this way, it won't get randomly assigned.
+            # at the end of the function, it gets properly assigned
+            mask[:, SRTM_INDEX] = True
+            # then, we flatten the mask and dw arrays
+            all_tokens_mask = mask.flatten()
+            unmasked_tokens = all_tokens_mask == False
+            idx = np.flatnonzero(unmasked_tokens)
+            np.random.shuffle(idx)
+            idx = idx[:num_tokens_to_mask]
+            all_tokens_mask[idx] = True
+            mask = all_tokens_mask.reshape((NUM_TIMESTEPS, len(BANDS_GROUPS_IDX)))
+        return mask
+
+    # RANDOM BANDS
+    if strategy == "random_combinations":
+        srtm_mask, num_tokens_to_mask = mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio)
+        mask = random_masking(mask, num_tokens_to_mask)
+
+    elif strategy == "group_bands":
+        srtm_mask, num_tokens_to_mask = mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio)
+        # next, we figure out how many tokens we can mask
+        num_band_groups_to_mask = int(num_tokens_to_mask / NUM_TIMESTEPS)
+        num_tokens_to_mask -= NUM_TIMESTEPS * num_band_groups_to_mask
+        assert num_tokens_to_mask >= 0
+        # tuple because of mypy, which thinks lists can only hold one type
+        band_groups: List[Any] = list(range(len(BANDS_GROUPS_IDX)))
+        band_groups.remove(SRTM_INDEX)
+        band_groups_to_mask = sample(band_groups, num_band_groups_to_mask)
+        for band_group in band_groups_to_mask:
+            mask[:, band_group] = True
+        mask = random_masking(mask, num_tokens_to_mask)
+
+    # RANDOM TIMESTEPS
+    elif strategy == "random_timesteps":
+        srtm_mask, num_tokens_to_mask = mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio)
+        # -1 for SRTM
+        timesteps_to_mask = int(num_tokens_to_mask / (len(BANDS_GROUPS_IDX) - 1))
+        num_tokens_to_mask -= (len(BANDS_GROUPS_IDX) - 1) * timesteps_to_mask
+        timesteps = sample(TIMESTEPS_IDX, k=timesteps_to_mask)
+        mask[timesteps] = True
+        mask = random_masking(mask, num_tokens_to_mask)
+    elif strategy == "chunk_timesteps":
+        srtm_mask, num_tokens_to_mask = mask_topography(srtm_mask, num_tokens_to_mask, mask_ratio)
+        # -1 for SRTM
+        timesteps_to_mask = int(num_tokens_to_mask / (len(BANDS_GROUPS_IDX) - 1))
+        num_tokens_to_mask -= (len(BANDS_GROUPS_IDX) - 1) * timesteps_to_mask
+        start_idx = randint(0, NUM_TIMESTEPS - timesteps_to_mask)
+        mask[start_idx : start_idx + timesteps_to_mask] = True  # noqa
+        mask = random_masking(mask, num_tokens_to_mask)
+    else:
+        raise ValueError(f"Unknown strategy {strategy} not in {MASK_STRATEGIES}")
+
+    mask[:, SRTM_INDEX] = srtm_mask
+    return np.repeat(mask, BAND_EXPANSION, axis=1)
+
+
+@dataclass
+class MaskParamsNoDw:
+    strategies: Tuple[str, ...] = ("NDVI",)
+    ratio: float = 0.5
+
+    def __post_init__(self):
+        for strategy in self.strategies:
+            assert strategy in [
+                "group_bands",
+                "random_timesteps",
+                "chunk_timesteps",
+                "random_combinations",
+            ]
+
+    def mask_data(self, eo_data: np.ndarray):
+        strategy = choice(self.strategies)
+        mask = make_mask_no_dw(strategy=strategy, mask_ratio=self.ratio)
+        x = eo_data * ~mask
+        y = np.zeros(eo_data.shape).astype(np.float32)
+        y[mask] = eo_data[mask]
+
+        return mask, x, y, strategy
 
 
 class WorldCerealDataset(Dataset):
-    def __init__(self, dataframe: pd.DataFrame, mask_params: Optional[MaskParams] = None):
+    def __init__(self, dataframe: pd.DataFrame, mask_params: Optional[MaskParamsNoDw] = None):
         self.df = dataframe
         self.mask_params = mask_params
 
@@ -19,77 +131,124 @@ class WorldCerealDataset(Dataset):
         return self.df.shape[0]
 
     def __getitem__(self, idx):
-        
+
         # Get the sample
         row = self.df.iloc[idx, :]
-        
+
         # Convert inputs and return
         return self.convert_inputs(row)
-    
+
     def convert_inputs(self, row):
-        
+
         # Latitude/Longitude
         latlon = torch.tensor([row.lat, row.lon]).float()
-        
+
         # Month
-        month = datetime.strptime(row.start_date, '%Y-%m-%d').month - 1
+        month = datetime.strptime(row.start_date, "%Y-%m-%d").month - 1
         month = torch.tensor(month).long()
 
         # Sentinel-2
         s2_band_mapping = {
-            'B02': 'B2',
-            'B03': 'B3',
-            'B04': 'B4',
-            'B05': 'B5',
-            'B06': 'B6',
-            'B07': 'B7',
-            'B08': 'B8',
-            'B8A': 'B8A',
-            'B11': 'B11',
-            'B12': 'B12'
+            "B02": "B2",
+            "B03": "B3",
+            "B04": "B4",
+            "B05": "B5",
+            "B06": "B6",
+            "B07": "B7",
+            "B08": "B8",
+            "B8A": "B8A",
+            "B11": "B11",
+            "B12": "B12",
         }
 
-        single_sample = pd.DataFrame(index=['ts0', 'ts1', 'ts2', 'ts3', 'ts4', 'ts5', 'ts6', 'ts7', 'ts8', 'ts9', 'ts10', 'ts11'])
+        single_sample = pd.DataFrame(
+            index=[
+                "ts0",
+                "ts1",
+                "ts2",
+                "ts3",
+                "ts4",
+                "ts5",
+                "ts6",
+                "ts7",
+                "ts8",
+                "ts9",
+                "ts10",
+                "ts11",
+            ]
+        )
         for b in s2_band_mapping.keys():
-            fts = [x for x in self.df.columns if b in x and 'ts' in x]
+            fts = [x for x in self.df.columns if b in x and "ts" in x]
             single_sample[b] = row[fts].values.astype(int)
 
         s2_data = torch.from_numpy(single_sample.values).float()
 
         # Sentinel-1
-        s1bands = ['VV', 'VH']
-        single_sample = pd.DataFrame(index=['ts0', 'ts1', 'ts2', 'ts3', 'ts4', 'ts5', 'ts6', 'ts7', 'ts8', 'ts9', 'ts10', 'ts11'])
+        s1bands = ["VV", "VH"]
+        single_sample = pd.DataFrame(
+            index=[
+                "ts0",
+                "ts1",
+                "ts2",
+                "ts3",
+                "ts4",
+                "ts5",
+                "ts6",
+                "ts7",
+                "ts8",
+                "ts9",
+                "ts10",
+                "ts11",
+            ]
+        )
         for b in s1bands:
-            fts = [x for x in self.df.columns if b in x and 'ts' in x]
+            fts = [x for x in self.df.columns if b in x and "ts" in x]
             values = row[fts].values.astype(float)
             idx_valid = values != 0
-            values[idx_valid] = (20 * np.log10(values[idx_valid]) - 83)
+            values[idx_valid] = 20 * np.log10(values[idx_valid]) - 83
             # values[~idx_valid] = -999 # Custom nodata  # Don't do this as long as we can't update the mask
             single_sample[b] = values
 
         s1_data = torch.from_numpy(single_sample.values).float()
 
         # METEO
-        single_sample = pd.DataFrame(index=['ts0', 'ts1', 'ts2', 'ts3', 'ts4', 'ts5', 'ts6', 'ts7', 'ts8', 'ts9', 'ts10', 'ts11'])
+        single_sample = pd.DataFrame(
+            index=[
+                "ts0",
+                "ts1",
+                "ts2",
+                "ts3",
+                "ts4",
+                "ts5",
+                "ts6",
+                "ts7",
+                "ts8",
+                "ts9",
+                "ts10",
+                "ts11",
+            ]
+        )
         meteo_band_mapping = {
-            'temperature_mean': 'temperature_2m',
-            'precipitation_flux': 'total_precipitation'
+            "temperature_mean": "temperature_2m",
+            "precipitation_flux": "total_precipitation",
         }
         for b in meteo_band_mapping.keys():
-            fts = [x for x in self.df.columns if b in x and 'ts' in x]
+            fts = [x for x in self.df.columns if b in x and "ts" in x]
             values = row[fts].values.astype(float)
             idx_valid = values != 0
-            values = values / 100.
+            values = values / 100.0
 
-            if b == 'precipitation_flux':
-                values =values / 1000.
+            if b == "precipitation_flux":
+                values = values / 1000.0
             # idx_valid[~idx_valid] = -999 # Custom nodata # Custom nodata  # Don't do this as long as we can't update the mask
             single_sample[b] = values
 
         meteo_data = torch.from_numpy(single_sample.values).float()
 
         # Alt/slope
-        srtm_data = np.repeat(row[['DEM-alt-20m', 'DEM-slo-20m']].values.reshape((1, 2)), 12, axis=0)
+        srtm_data = np.repeat(
+            row[["DEM-alt-20m", "DEM-slo-20m"]].values.reshape((1, 2)), 12, axis=0
+        )
         srtm_data = torch.from_numpy(srtm_data.astype(float)).float()
 
         # Construct normalized Presto inputs
@@ -97,17 +256,21 @@ class WorldCerealDataset(Dataset):
         # of all the required normalizations
         # the `mask` is not going to be used in training mode
         x, mask, dynamic_world = presto.construct_single_presto_input(
-            s2=s2_data, s2_bands=list(s2_band_mapping.values()),
-            s1=s1_data, s1_bands=s1bands,
-            era5=meteo_data, era5_bands=list(meteo_band_mapping.values()),
-            srtm=srtm_data, srtm_bands=["elevation", "slope"]
+            s2=s2_data,
+            s2_bands=list(s2_band_mapping.values()),
+            s1=s1_data,
+            s1_bands=s1bands,
+            era5=meteo_data,
+            era5_bands=list(meteo_band_mapping.values()),
+            srtm=srtm_data,
+            srtm_bands=["elevation", "slope"],
         )
 
-        '''
+        """
         Adjusting the mask cannot be done for now, as Presto code
         requires all elements in the batch to be masked equally
         cfr. https://github.com/nasaharvest/presto/issues/26#issuecomment-1777120102
-        
+
         # --------------------------------------------------------
         # Adjust the mask so nodata values are dealt with properly
         #
@@ -131,22 +294,22 @@ class WorldCerealDataset(Dataset):
         # Meteo
         if -999 in meteo_data:
             mask[torch.where(meteo_data == -999)] = 1
-        '''
-        
+        """
+
         if self.mask_params is None:
             # return in the format we can encode it with Presto
             return x.float(), mask.bool(), dynamic_world.long(), latlon, month
         else:
             # return it the way it's done for Presto training
-            mask_eo, mask_dw, x_eo, y_eo, x_dw, y_dw, strat = self.mask_params.mask_data(
-                x.numpy(), dynamic_world.numpy()
-            )
+            mask_dw = np.full(NUM_TIMESTEPS, True)
+            y_dw = dynamic_world.detach().clone()
+            mask_eo, x_eo, y_eo, strat = self.mask_params.mask_data(x.numpy())
             return MaskedExample(
                 mask_eo,
                 mask_dw,
                 x_eo,
                 y_eo,
-                x_dw,
+                dynamic_world,
                 y_dw,
                 month,
                 latlon,

--- a/notebooks/ewoc_train_script.py
+++ b/notebooks/ewoc_train_script.py
@@ -1,0 +1,219 @@
+# presto_pretrain_finetune, but in a notebook
+import json
+import logging
+from pathlib import Path
+
+import pandas as pd
+import torch
+import torch.nn as nn
+from torch import optim
+from tqdm import tqdm
+
+from presto import Presto
+from presto.dataops import BANDS_GROUPS_IDX, MASK_STRATEGIES
+from presto.model import LossWrapper, adjust_learning_rate, param_groups_weight_decay
+from presto.utils import (
+    DEFAULT_SEED,
+    config_dir,
+    device,
+    initialize_logging,
+    seed_everything,
+    timestamp_dirname,
+)
+
+logger = logging.getLogger("__main__")
+
+
+model_name = "presto_worldcereal"
+seed = DEFAULT_SEED
+seed_everything(seed)
+output_parent_dir = Path(".")
+run_id = None
+
+logging_dir = output_parent_dir / "output" / timestamp_dirname(run_id)
+logging_dir.mkdir(exist_ok=True, parents=True)
+initialize_logging(logging_dir)
+logger.info("Using output dir: %s" % logging_dir)
+
+# Taken the defaults for now
+num_epochs = 20
+val_per_n_steps = 1000
+dynamic_world_loss_weight = 2  # Set to 0 if we don't have DW?
+max_learning_rate = 0.0001  # 0.001 is default, for finetuning max should be lower?
+min_learning_rate = 0
+warmup_epochs = 2
+weight_decay = 0.05
+batch_size = 4096  # default 4096
+
+# Default mask strategies and mask_ratio
+mask_strategies = MASK_STRATEGIES
+mask_ratio: float = 0.75
+
+path_to_config = config_dir / "default.json"
+model_kwargs = json.load(Path(path_to_config).open("r"))
+
+
+df = pd.read_parquet("worldcereal_testdf.parquet")
+
+
+from ewoc_presto import MaskParamsNoDw, WorldCerealDataset
+from torch.utils.data import DataLoader
+
+logger.info("Setting up dataloaders")
+
+# Load the mask parameters
+mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)
+
+# Create the WorldCereal dataset
+ds = WorldCerealDataset(df, mask_params=mask_params)
+
+# Create DataLoaders from the dataset. For now, without shame using same data for train and val
+# we're just testing functionality ;-)
+train_dataloader = DataLoader(ds, batch_size=batch_size, shuffle=True)
+val_dataloader = DataLoader(ds, batch_size=batch_size, shuffle=False)
+
+
+logger.info("Setting up model")
+model = Presto.load_pretrained()
+model.to(device)
+
+# Model hyperparameters: keep unchanged for now
+param_groups = param_groups_weight_decay(model, weight_decay)
+optimizer = optim.AdamW(param_groups, lr=max_learning_rate, betas=(0.9, 0.95))
+mse = LossWrapper(nn.MSELoss())
+ce = LossWrapper(nn.CrossEntropyLoss())
+
+training_config = {
+    "model": model.__class__,
+    "encoder": model.encoder.__class__,
+    "decoder": model.decoder.__class__,
+    "optimizer": optimizer.__class__.__name__,
+    "eo_loss": mse.loss.__class__.__name__,
+    "dynamic_world_loss": ce.loss.__class__.__name__,
+    "device": device,
+    "logging_dir": logging_dir,
+    # **args,
+    # **model_kwargs,
+}
+
+lowest_validation_loss = None
+best_val_epoch = 0
+training_step = 0
+num_validations = 0
+dataloader_length = df.shape[0]
+
+with tqdm(range(num_epochs), desc="Epoch") as tqdm_epoch:
+    for epoch in tqdm_epoch:
+        # ------------------------ Training ----------------------------------------
+        total_eo_train_loss = 0.0
+        num_updates_being_captured = 0
+        train_size = 0
+        model.train()
+        for epoch_step, b in enumerate(tqdm(train_dataloader, desc="Train", leave=False)):
+            mask, x, y, start_month = b[0].to(device), b[2].to(device), b[3].to(device), b[6]
+            dw_mask, x_dw, y_dw = b[1].to(device), b[4].to(device).long(), b[5].to(device).long()
+            latlons = b[7].to(device)
+            # zero the parameter gradients
+            optimizer.zero_grad()
+            lr = adjust_learning_rate(
+                optimizer,
+                epoch_step / dataloader_length + epoch,
+                warmup_epochs,
+                num_epochs,
+                max_learning_rate,
+                min_learning_rate,
+            )
+            # Get model outputs and calculate loss
+            y_pred, dw_pred = model(
+                x, mask=mask, dynamic_world=x_dw, latlons=latlons, month=start_month
+            )
+            # set all SRTM timesteps except the first one to unmasked, so that
+            # they will get ignored by the loss function even if the SRTM
+            # value was masked
+            mask[:, 1:, BANDS_GROUPS_IDX["SRTM"]] = False
+            loss = mse(y_pred[mask], y[mask])
+            loss.backward()
+            optimizer.step()
+
+            current_batch_size = len(x)
+            total_eo_train_loss += loss.item()
+            num_updates_being_captured += 1
+            train_size += current_batch_size
+            training_step += 1
+
+            # ------------------------ Validation --------------------------------------
+            if training_step % val_per_n_steps == 0:
+                total_eo_val_loss = 0.0
+                num_val_updates_captured = 0
+                val_size = 0
+                model.eval()
+                with torch.no_grad():
+                    for b in tqdm(val_dataloader, desc="Validate"):
+                        mask, x, y, start_month = (
+                            b[0].to(device),
+                            b[2].to(device),
+                            b[3].to(device),
+                            b[6],
+                        )
+                        dw_mask, x_dw = b[1].to(device), b[4].to(device).long()
+                        y_dw, latlons = b[5].to(device).long(), b[7].to(device)
+                        # Get model outputs and calculate loss
+                        y_pred, dw_pred = model(
+                            x, mask=mask, dynamic_world=x_dw, latlons=latlons, month=start_month
+                        )
+                        # set all SRTM timesteps except the first one to unmasked, so that
+                        # they will get ignored by the loss function even if the SRTM
+                        # value was masked
+                        mask[:, 1:, BANDS_GROUPS_IDX["SRTM"]] = False
+                        loss = mse(y_pred[mask], y[mask])
+                        current_batch_size = len(x)
+                        total_eo_val_loss += loss.item()
+                        num_val_updates_captured += 1
+
+                # ------------------------ Metrics + Logging -------------------------------
+                # train_loss now reflects the value against which we calculate gradients
+                train_eo_loss = total_eo_train_loss / num_updates_being_captured
+                val_eo_loss = total_eo_val_loss / num_val_updates_captured
+
+                if "train_size" not in training_config and "val_size" not in training_config:
+                    training_config["train_size"] = train_size
+                    training_config["val_size"] = val_size
+                    # if wandb_enabled:
+                    #     wandb.config.update(training_config)
+
+                to_log = {
+                    "train_eo_loss": train_eo_loss,
+                    "val_eo_loss": val_eo_loss,
+                    "training_step": training_step,
+                    "epoch": epoch,
+                    "lr": lr,
+                }
+                tqdm_epoch.set_postfix(loss=val_eo_loss)
+
+                if lowest_validation_loss is None or val_eo_loss < lowest_validation_loss:
+                    lowest_validation_loss = val_eo_loss
+                    best_val_epoch = epoch
+
+                    model_path = logging_dir / Path("models")
+                    model_path.mkdir(exist_ok=True, parents=True)
+
+                    best_model_path = model_path / f"{model_name}{epoch}.pt"
+                    logger.info(f"Saving best model to: {best_model_path}")
+                    torch.save(model.state_dict(), best_model_path)
+
+                # reset training logging
+                total_eo_train_loss = 0.0
+                num_updates_being_captured = 0
+                train_size = 0
+                num_validations += 1
+
+                # if wandb_enabled:
+                #     model.eval()
+                #     for title, plot in plot_predictions(model):
+                #         to_log[title] = plot
+                #     wandb.log(to_log)
+                #     plt.close("all")
+
+                model.train()
+
+logger.info(f"Done training, best model saved to {best_model_path}")

--- a/notebooks/presto_pretrain_finetune.ipynb
+++ b/notebooks/presto_pretrain_finetune.ipynb
@@ -12,12 +12,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "id": "f161c3be-3e4e-460e-a7e5-b8febf1b1e77",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/gabrieltseng/anaconda3/envs/lem/lib/python3.9/site-packages/geopandas/_compat.py:106: UserWarning: The Shapely GEOS version (3.11.1-CAPI-1.17.1) is incompatible with the GEOS version PyGEOS was compiled with (3.10.4-CAPI-1.16.2). Conversions between both will be slow.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "import json\n",
     "import logging\n",
@@ -33,7 +42,7 @@
     "from tqdm import tqdm\n",
     "\n",
     "from presto import Presto\n",
-    "from presto.dataops import BANDS_GROUPS_IDX, MASK_STRATEGIES, MaskParams\n",
+    "from presto.dataops import BANDS_GROUPS_IDX, MASK_STRATEGIES\n",
     "\n",
     "\n",
     "from presto.model import LossWrapper, adjust_learning_rate, param_groups_weight_decay\n",
@@ -52,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "id": "db440dbb-8b2b-41fc-81ee-3e3dcd47dff6",
    "metadata": {
     "tags": []
@@ -62,10 +71,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "25-10-2023 18:42:15 - INFO - Initialized logging to output/2023_10_25_18_42_15_093321/console-output.log\n",
-      "25-10-2023 18:42:15 - INFO - Initialized logging to output/2023_10_25_18_42_15_093321/console-output.log\n",
-      "25-10-2023 18:42:15 - INFO - Using output dir: output/2023_10_25_18_42_15_093321\n",
-      "25-10-2023 18:42:15 - INFO - Using output dir: output/2023_10_25_18_42_15_093321\n"
+      "26-10-2023 11:20:42 - INFO - Initialized logging to output/2023_10_26_11_20_42_680240/console-output.log\n",
+      "26-10-2023 11:20:42 - INFO - Using output dir: output/2023_10_26_11_20_42_680240\n"
      ]
     }
    ],
@@ -89,7 +96,7 @@
     "min_learning_rate = 0\n",
     "warmup_epochs = 2\n",
     "weight_decay = 0.05\n",
-    "batch_size = 1  # default 4096\n",
+    "batch_size = 2  # default 4096\n",
     "\n",
     "# Default mask strategies and mask_ratio\n",
     "mask_strategies = MASK_STRATEGIES\n",
@@ -113,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "c58bc99f-3ac8-4a31-8e1c-a5ae4ffeedbc",
    "metadata": {
     "tags": []
@@ -328,7 +335,7 @@
        "[5 rows x 183 columns]"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -351,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 4,
    "id": "69fbccfe-8434-42d5-8f4f-086eca85267c",
    "metadata": {
     "tags": []
@@ -361,19 +368,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "25-10-2023 18:42:18 - INFO - Setting up dataloaders\n",
-      "25-10-2023 18:42:18 - INFO - Setting up dataloaders\n"
+      "26-10-2023 11:20:42 - INFO - Setting up dataloaders\n"
      ]
     }
    ],
    "source": [
-    "from ewoc_presto import WorldCerealDataset\n",
+    "from ewoc_presto import WorldCerealDataset, MaskParamsNoDw\n",
     "from torch.utils.data import DataLoader\n",
     "\n",
     "logger.info(\"Setting up dataloaders\")\n",
     "\n",
     "# Load the mask parameters\n",
-    "mask_params = MaskParams(mask_strategies, mask_ratio)\n",
+    "mask_params = MaskParamsNoDw(mask_strategies, mask_ratio)\n",
     "\n",
     "# Create the WorldCereal dataset\n",
     "ds = WorldCerealDataset(df, mask_params=mask_params)\n",
@@ -394,54 +400,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "c8e7dc72-5b74-4b75-a3fa-05e28ef541e9",
    "metadata": {
+    "scrolled": true,
     "tags": []
    },
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "72\n",
+      "group_bands\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "MaskedExample(mask_eo=array([[ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
+       "MaskedExample(mask_eo=array([[ True,  True,  True,  True,  True, False, False, False, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True, False],\n",
+       "       [ True,  True,  True,  True,  True, False, False, False, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True, False],\n",
+       "       [ True,  True,  True,  True,  True, False, False, False, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True,  True],\n",
+       "       [ True,  True,  True,  True,  True,  True,  True,  True, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True, False],\n",
        "       [ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "         True,  True,  True,  True,  True,  True,  True, False],\n",
        "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
+       "         True,  True,  True,  True,  True,  True,  True,  True],\n",
+       "       [ True,  True,  True,  True,  True, False, False, False, False,\n",
        "         True,  True,  True,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True,  True],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True, False],\n",
+       "       [ True,  True,  True,  True,  True,  True,  True,  True, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True, False],\n",
+       "       [ True,  True,  True,  True,  True, False, False, False, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True,  True],\n",
+       "       [ True,  True,  True,  True,  True, False, False, False, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True, False],\n",
        "       [ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "         True,  True,  True,  True,  True,  True,  True, False],\n",
-       "       [ True,  True,  True,  True,  True, False, False, False,  True,\n",
-       "         True, False, False,  True,  True,  True,  True,  True]]), mask_dw=array([ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
+       "       [ True,  True,  True,  True,  True, False, False, False, False,\n",
+       "         True,  True,  True,  True,  True,  True,  True,  True]]), mask_dw=array([ True,  True,  True,  True,  True,  True,  True,  True,  True,\n",
        "        True,  True,  True]), x_eo=array([[0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.1019    , 0.1503    , 0.166     , 0.        , 0.        ,\n",
-       "        0.1535    , 0.0989    , 0.        , 0.        , 0.        ,\n",
+       "        0.1019    , 0.1503    , 0.166     , 0.1427    , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.3449576 ],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        ],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.1346    , 0.1954    , 0.2099    , 0.        , 0.        ,\n",
-       "        0.1832    , 0.1263    , 0.        , 0.        , 0.        ,\n",
-       "        0.        , 0.3669243 ],\n",
+       "        0.1346    , 0.1954    , 0.2099    , 0.2211    , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.        , 0.        ],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.1353    , 0.2045    , 0.2241    , 0.        , 0.        ,\n",
-       "        0.1706    , 0.1067    , 0.        , 0.        , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.228     , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.40958264],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
@@ -450,33 +465,33 @@
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.1041    , 0.2315    , 0.284     , 0.        , 0.        ,\n",
        "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.        , 0.6640794 ],\n",
-       "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.0976    , 0.2935    , 0.3797    , 0.        , 0.        ,\n",
-       "        0.1708    , 0.0986    , 0.        , 0.        , 0.        ,\n",
-       "        0.        , 0.794592  ],\n",
-       "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.1556    , 0.0773    , 0.        , 0.        , 0.        ,\n",
-       "        0.        , 0.81214   ],\n",
-       "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.1725    , 0.2673    , 0.3199    , 0.        , 0.        ,\n",
-       "        0.2067    , 0.1265    , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        ],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.2005    , 0.257     , 0.279     , 0.        , 0.        ,\n",
-       "        0.3017    , 0.2286    , 0.        , 0.        , 0.        ,\n",
+       "        0.0976    , 0.2935    , 0.3797    , 0.3783    , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.        , 0.794592  ],\n",
+       "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.409     , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.        , 0.81214   ],\n",
+       "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.1725    , 0.2673    , 0.3199    , 0.3368    , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.        , 0.        ],\n",
+       "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
+       "        0.2005    , 0.257     , 0.279     , 0.3028    , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.25565   ],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.31101024],\n",
        "       [0.        , 0.        , 0.        , 0.        , 0.        ,\n",
-       "        0.1292    , 0.1477    , 0.1639    , 0.        , 0.        ,\n",
-       "        0.2095    , 0.1863    , 0.        , 0.        , 0.        ,\n",
+       "        0.1292    , 0.1477    , 0.1639    , 0.1638    , 0.        ,\n",
+       "        0.        , 0.        , 0.        , 0.        , 0.        ,\n",
        "        0.        , 0.        ]], dtype=float32), y_eo=array([[7.1070445e-01, 4.0414044e-01, 4.6799999e-02, 6.3299999e-02,\n",
        "        6.9499999e-02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        1.4270000e-01, 1.7900001e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 1.7900001e-01, 1.5350001e-01, 9.8899998e-02,\n",
        "        2.8600028e-01, 1.7580000e+00, 8.0000004e-03, 2.2097086e-04,\n",
        "        0.0000000e+00],\n",
        "       [7.6310456e-01, 4.4350997e-01, 0.0000000e+00, 0.0000000e+00,\n",
@@ -486,12 +501,12 @@
        "        0.0000000e+00],\n",
        "       [7.7439803e-01, 4.4943887e-01, 5.8100000e-02, 8.9000002e-02,\n",
        "        1.0240000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        2.2110000e-01, 2.2900000e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 2.2900000e-01, 1.8320000e-01, 1.2630001e-01,\n",
        "        1.9371425e-01, 3.5703335e+00, 8.0000004e-03, 2.2097086e-04,\n",
-       "        0.0000000e+00],\n",
+       "        3.6692429e-01],\n",
        "       [7.4385452e-01, 4.0304527e-01, 5.3399999e-02, 8.3099999e-02,\n",
-       "        9.5500000e-02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        2.2800000e-01, 2.4140000e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        9.5500000e-02, 1.3530000e-01, 2.0450000e-01, 2.2409999e-01,\n",
+       "        0.0000000e+00, 2.4140000e-01, 1.7060000e-01, 1.0670000e-01,\n",
        "        1.2000035e-01, 1.4010000e+00, 8.0000004e-03, 2.2097086e-04,\n",
        "        0.0000000e+00],\n",
        "       [7.1858895e-01, 3.6650026e-01, 6.7000002e-02, 8.9900002e-02,\n",
@@ -503,25 +518,25 @@
        "        5.4099999e-02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
        "        2.6800001e-01, 2.9820001e-01, 1.6370000e-01, 9.5500000e-02,\n",
        "        3.3199987e-01, 2.6080000e+00, 8.0000004e-03, 2.2097086e-04,\n",
-       "        0.0000000e+00],\n",
+       "        6.6407943e-01],\n",
        "       [4.8248756e-01, 3.1345016e-01, 3.2900002e-02, 6.3400000e-02,\n",
        "        4.3299999e-02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        3.7830001e-01, 4.0000001e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 4.0000001e-01, 1.7080000e-01, 9.8600000e-02,\n",
        "        3.5657173e-01, 2.7900002e+00, 8.0000004e-03, 2.2097086e-04,\n",
        "        0.0000000e+00],\n",
        "       [5.0303054e-01, 3.1309509e-01, 4.5800000e-02, 6.2300000e-02,\n",
        "        4.2399999e-02, 8.6999997e-02, 2.9620001e-01, 4.1389999e-01,\n",
-       "        4.0900001e-01, 4.4100001e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 4.4100001e-01, 1.5560000e-01, 7.7299997e-02,\n",
        "        4.9171403e-01, 8.6833334e-01, 8.0000004e-03, 2.2097086e-04,\n",
        "        0.0000000e+00],\n",
        "       [6.1433578e-01, 3.7268978e-01, 6.5300003e-02, 1.0580000e-01,\n",
        "        1.1890000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        3.3680001e-01, 3.6379999e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 3.6379999e-01, 2.0670000e-01, 1.2650000e-01,\n",
        "        5.7457191e-01, 1.8366668e-01, 8.0000004e-03, 2.2097086e-04,\n",
        "        4.7816548e-01],\n",
        "       [6.6410881e-01, 3.2872450e-01, 1.2610000e-01, 1.5770000e-01,\n",
        "        1.7950000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        3.0280000e-01, 3.0300000e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 3.0300000e-01, 3.0170000e-01, 2.2860000e-01,\n",
        "        5.9200001e-01, 2.0303335e+00, 8.0000004e-03, 2.2097086e-04,\n",
        "        0.0000000e+00],\n",
        "       [5.9743655e-01, 2.8575873e-01, 7.5400002e-02, 1.0820000e-01,\n",
@@ -531,12 +546,12 @@
        "        0.0000000e+00],\n",
        "       [5.5043799e-01, 2.3649834e-01, 5.7000000e-02, 8.2699999e-02,\n",
        "        9.9299997e-02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00,\n",
-       "        1.6380000e-01, 1.8080001e-01, 0.0000000e+00, 0.0000000e+00,\n",
+       "        0.0000000e+00, 1.8080001e-01, 2.0950000e-01, 1.8629999e-01,\n",
        "        4.0114310e-01, 1.3730000e+00, 8.0000004e-03, 2.2097086e-04,\n",
-       "        2.4515395e-01]], dtype=float32), x_dw=array([9., 9., 9., 9., 9., 9., 9., 9., 9., 9., 9., 9.], dtype=float32), y_dw=array([9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9], dtype=int16), start_month=tensor(9), latlon=tensor([50.8979,  2.6686]), strategy='group_bands')"
+       "        2.4515395e-01]], dtype=float32), x_dw=tensor([9., 9., 9., 9., 9., 9., 9., 9., 9., 9., 9., 9.]), y_dw=tensor([9., 9., 9., 9., 9., 9., 9., 9., 9., 9., 9., 9.]), start_month=tensor(9), latlon=tensor([50.8979,  2.6686]), strategy='group_bands')"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -555,7 +570,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "b1793713-09a7-4dd0-a7c0-30a7f4dd4d3e",
    "metadata": {
     "tags": []
@@ -565,8 +580,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "25-10-2023 18:42:24 - INFO - Setting up model\n",
-      "25-10-2023 18:42:24 - INFO - Setting up model\n"
+      "26-10-2023 11:20:43 - INFO - Setting up model\n"
      ]
     },
     {
@@ -658,7 +672,7 @@
        ")"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,7 +685,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 7,
    "id": "814fc9c4-6eb0-4a19-be5e-796e56083563",
    "metadata": {
     "tags": []
@@ -710,7 +724,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 8,
    "id": "ddfada35-31de-4e99-b2fb-014ba12eb5dc",
    "metadata": {
     "tags": []
@@ -720,20 +734,79 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Epoch:   0%|          | 0/20 [00:00<?, ?it/s]\n",
-      "Train:   0%|          | 0/500 [00:00<?, ?it/s]\u001b[A\n",
-      "Epoch:   0%|          | 0/20 [00:01<?, ?it/s] \u001b[A\n"
+      "\r",
+      "Epoch:   0%|                                                            | 0/20 [00:00<?, ?it/s]"
      ]
     },
     {
-     "ename": "NameError",
-     "evalue": "name 'BANDS_GROUPS_IDX' is not defined",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch: 0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Train:   0%|                                                           | 0/250 [00:00<?, ?it/s]\u001b[A\n",
+      "Train:   0%|▏                                                  | 1/250 [00:00<00:28,  8.67it/s]\u001b[A"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "72\n",
+      "group_bands\n",
+      "72\n",
+      "group_bands\n",
+      "72\n",
+      "group_bands\n",
+      "72\n",
+      "random_timesteps\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Epoch:   0%|                                                            | 0/20 [00:00<?, ?it/s]\u001b[A"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "72\n",
+      "group_bands\n",
+      "72\n",
+      "chunk_timesteps\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "10752, 9856",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[19], line 39\u001b[0m\n\u001b[1;32m     33\u001b[0m y_pred, dw_pred \u001b[38;5;241m=\u001b[39m model(\n\u001b[1;32m     34\u001b[0m     x, mask\u001b[38;5;241m=\u001b[39mmask, dynamic_world\u001b[38;5;241m=\u001b[39mx_dw, latlons\u001b[38;5;241m=\u001b[39mlatlons, month\u001b[38;5;241m=\u001b[39mstart_month\n\u001b[1;32m     35\u001b[0m )\n\u001b[1;32m     36\u001b[0m \u001b[38;5;66;03m# set all SRTM timesteps except the first one to unmasked, so that\u001b[39;00m\n\u001b[1;32m     37\u001b[0m \u001b[38;5;66;03m# they will get ignored by the loss function even if the SRTM\u001b[39;00m\n\u001b[1;32m     38\u001b[0m \u001b[38;5;66;03m# value was masked\u001b[39;00m\n\u001b[0;32m---> 39\u001b[0m mask[:, \u001b[38;5;241m1\u001b[39m:, \u001b[43mBANDS_GROUPS_IDX\u001b[49m[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSRTM\u001b[39m\u001b[38;5;124m\"\u001b[39m]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n\u001b[1;32m     40\u001b[0m loss \u001b[38;5;241m=\u001b[39m mse(y_pred[mask], y[mask])\n\u001b[1;32m     41\u001b[0m dw_loss \u001b[38;5;241m=\u001b[39m ce(dw_pred[dw_mask], y_dw[dw_mask])\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'BANDS_GROUPS_IDX' is not defined"
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 30\u001b[0m\n\u001b[1;32m     21\u001b[0m lr \u001b[38;5;241m=\u001b[39m adjust_learning_rate(\n\u001b[1;32m     22\u001b[0m     optimizer,\n\u001b[1;32m     23\u001b[0m     epoch_step \u001b[38;5;241m/\u001b[39m dataloader_length \u001b[38;5;241m+\u001b[39m epoch,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     27\u001b[0m     min_learning_rate,\n\u001b[1;32m     28\u001b[0m )\n\u001b[1;32m     29\u001b[0m \u001b[38;5;66;03m# Get model outputs and calculate loss\u001b[39;00m\n\u001b[0;32m---> 30\u001b[0m y_pred, dw_pred \u001b[38;5;241m=\u001b[39m \u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     31\u001b[0m \u001b[43m    \u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdynamic_world\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mx_dw\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlatlons\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlatlons\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmonth\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mstart_month\u001b[49m\n\u001b[1;32m     32\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;66;03m# set all SRTM timesteps except the first one to unmasked, so that\u001b[39;00m\n\u001b[1;32m     34\u001b[0m \u001b[38;5;66;03m# they will get ignored by the loss function even if the SRTM\u001b[39;00m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;66;03m# value was masked\u001b[39;00m\n\u001b[1;32m     36\u001b[0m mask[:, \u001b[38;5;241m1\u001b[39m:, BANDS_GROUPS_IDX[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSRTM\u001b[39m\u001b[38;5;124m\"\u001b[39m]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/nn/modules/module.py:1501\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1496\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1497\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1498\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1499\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1500\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1501\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1502\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1503\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/Documents/code/presto/presto/presto.py:729\u001b[0m, in \u001b[0;36mPresto.forward\u001b[0;34m(self, x, dynamic_world, latlons, mask, month)\u001b[0m\n\u001b[1;32m    721\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\n\u001b[1;32m    722\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m    723\u001b[0m     x: torch\u001b[38;5;241m.\u001b[39mTensor,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    727\u001b[0m     month: Union[torch\u001b[38;5;241m.\u001b[39mTensor, \u001b[38;5;28mint\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m0\u001b[39m,\n\u001b[1;32m    728\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m torch\u001b[38;5;241m.\u001b[39mTensor:\n\u001b[0;32m--> 729\u001b[0m     x, kept_indices, removed_indices \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mencoder\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    730\u001b[0m \u001b[43m        \u001b[49m\u001b[43mx\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    731\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdynamic_world\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdynamic_world\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    732\u001b[0m \u001b[43m        \u001b[49m\u001b[43mlatlons\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlatlons\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    733\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    734\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmonth\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmonth\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    735\u001b[0m \u001b[43m        \u001b[49m\u001b[43meval_task\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    736\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    738\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdecoder(x, kept_indices, removed_indices, month)\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/nn/modules/module.py:1501\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1496\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1497\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1498\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1499\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1500\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1501\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1502\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1503\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
+      "File \u001b[0;32m~/Documents/code/presto/presto/presto.py:468\u001b[0m, in \u001b[0;36mEncoder.forward\u001b[0;34m(self, x, dynamic_world, latlons, mask, month, eval_task)\u001b[0m\n\u001b[1;32m    466\u001b[0m x \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mcat(all_tokens, dim\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)  \u001b[38;5;66;03m# [batch, timesteps, embedding_dim]\u001b[39;00m\n\u001b[1;32m    467\u001b[0m mask \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mcat(all_masks, dim\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)  \u001b[38;5;66;03m# [batch, timesteps, embedding_dim]\u001b[39;00m\n\u001b[0;32m--> 468\u001b[0m x, kept_indices, removed_indices \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmask_tokens\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmask\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    470\u001b[0m \u001b[38;5;66;03m# append latlon tokens\u001b[39;00m\n\u001b[1;32m    471\u001b[0m latlon_tokens \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlatlon_embed(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcartesian(latlons))\u001b[38;5;241m.\u001b[39munsqueeze(\u001b[38;5;241m1\u001b[39m)\n",
+      "File \u001b[0;32m~/Documents/code/presto/presto/presto.py:373\u001b[0m, in \u001b[0;36mEncoder.mask_tokens\u001b[0;34m(x, mask)\u001b[0m\n\u001b[1;32m    368\u001b[0m \u001b[38;5;129m@staticmethod\u001b[39m\n\u001b[1;32m    369\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmask_tokens\u001b[39m(x, mask):\n\u001b[1;32m    370\u001b[0m     summed \u001b[38;5;241m=\u001b[39m mask\u001b[38;5;241m.\u001b[39msum(\n\u001b[1;32m    371\u001b[0m         dim\u001b[38;5;241m=\u001b[39m(\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m)\n\u001b[1;32m    372\u001b[0m     )  \u001b[38;5;66;03m# summed tells me the number of masked elements per batch idx\u001b[39;00m\n\u001b[0;32m--> 373\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m summed\u001b[38;5;241m.\u001b[39mmax() \u001b[38;5;241m==\u001b[39m summed\u001b[38;5;241m.\u001b[39mmin(), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00msummed\u001b[38;5;241m.\u001b[39mmax()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m, \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msummed\u001b[38;5;241m.\u001b[39mmin()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    375\u001b[0m     batch_size \u001b[38;5;241m=\u001b[39m x\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    376\u001b[0m     removed_elements_per_batch \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mint\u001b[39m(summed\u001b[38;5;241m.\u001b[39mmax() \u001b[38;5;241m/\u001b[39m mask\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m2\u001b[39m])\n",
+      "\u001b[0;31mAssertionError\u001b[0m: 10752, 9856"
      ]
     }
    ],
@@ -746,12 +819,9 @@
     "\n",
     "with tqdm(range(num_epochs), desc=\"Epoch\") as tqdm_epoch:\n",
     "    for epoch in tqdm_epoch:\n",
+    "        print(f\"Epoch: {epoch}\")\n",
     "        # ------------------------ Training ----------------------------------------\n",
-    "        total_train_loss = 0.0\n",
     "        total_eo_train_loss = 0.0\n",
-    "        total_dw_train_loss = 0.0\n",
-    "        total_num_eo_values_masked = 0\n",
-    "        total_num_dw_values_masked = 0\n",
     "        num_updates_being_captured = 0\n",
     "        train_size = 0\n",
     "        model.train()\n",
@@ -778,34 +848,18 @@
     "            # value was masked\n",
     "            mask[:, 1:, BANDS_GROUPS_IDX[\"SRTM\"]] = False\n",
     "            loss = mse(y_pred[mask], y[mask])\n",
-    "            dw_loss = ce(dw_pred[dw_mask], y_dw[dw_mask])\n",
-    "            num_eo_masked, num_dw_masked = len(y_pred[mask]), len(dw_pred[dw_mask])\n",
-    "            with torch.no_grad():\n",
-    "                ratio = num_dw_masked / max(num_eo_masked, 1)\n",
-    "                # weight shouldn't be > 1\n",
-    "                weight = min(1, dynamic_world_loss_weight * ratio)\n",
-    "\n",
-    "            total_loss = loss + weight * dw_loss\n",
-    "            total_loss.backward()\n",
+    "            loss.backward()\n",
     "            optimizer.step()\n",
     "\n",
     "            current_batch_size = len(x)\n",
-    "            total_train_loss += total_loss.item()\n",
-    "            total_eo_train_loss += loss.item() * num_eo_masked\n",
-    "            total_dw_train_loss += dw_loss.item() * num_dw_masked\n",
-    "            total_num_eo_values_masked += num_eo_masked\n",
-    "            total_num_dw_values_masked += num_dw_masked\n",
+    "            total_eo_train_loss += loss.item()\n",
     "            num_updates_being_captured += 1\n",
     "            train_size += current_batch_size\n",
     "            training_step += 1\n",
     "\n",
     "            # ------------------------ Validation --------------------------------------\n",
     "            if training_step % val_per_n_steps == 0:\n",
-    "                total_val_loss = 0.0\n",
     "                total_eo_val_loss = 0.0\n",
-    "                total_dw_val_loss = 0.0\n",
-    "                total_val_num_eo_values_masked = 0\n",
-    "                total_val_num_dw_values_masked = 0\n",
     "                num_val_updates_captured = 0\n",
     "                val_size = 0\n",
     "                model.eval()\n",
@@ -828,31 +882,14 @@
     "                        # value was masked\n",
     "                        mask[:, 1:, BANDS_GROUPS_IDX[\"SRTM\"]] = False\n",
     "                        loss = mse(y_pred[mask], y[mask])\n",
-    "                        dw_loss = ce(dw_pred[dw_mask], y_dw[dw_mask])\n",
-    "                        num_eo_masked, num_dw_masked = len(y_pred[mask]), len(dw_pred[dw_mask])\n",
-    "                        with torch.no_grad():\n",
-    "                            ratio = num_dw_masked / max(num_eo_masked, 1)\n",
-    "                            # weight shouldn't be > 1\n",
-    "                            weight = min(1, dynamic_world_loss_weight * ratio)\n",
-    "                        total_loss = loss + weight * dw_loss\n",
     "                        current_batch_size = len(x)\n",
-    "                        val_size += current_batch_size\n",
-    "                        total_val_loss += total_loss.item()\n",
-    "                        total_eo_val_loss += loss.item() * num_eo_masked\n",
-    "                        total_dw_val_loss += dw_loss.item() * num_dw_masked\n",
-    "                        total_val_num_eo_values_masked += num_eo_masked\n",
-    "                        total_val_num_dw_values_masked += num_dw_masked\n",
+    "                        total_eo_val_loss += loss.item()\n",
     "                        num_val_updates_captured += 1\n",
     "\n",
     "                # ------------------------ Metrics + Logging -------------------------------\n",
     "                # train_loss now reflects the value against which we calculate gradients\n",
-    "                train_loss = total_train_loss / num_updates_being_captured\n",
-    "                train_eo_loss = total_eo_train_loss / max(total_num_eo_values_masked, 1)\n",
-    "                train_dw_loss = total_dw_train_loss / max(total_num_dw_values_masked, 1)\n",
-    "\n",
-    "                val_loss = total_val_loss / num_val_updates_captured\n",
-    "                val_eo_loss = total_eo_val_loss / max(total_val_num_eo_values_masked, 1)\n",
-    "                val_dw_loss = total_dw_val_loss / max(total_val_num_dw_values_masked, 1)\n",
+    "                train_eo_loss = total_eo_train_loss / num_updates_being_captured\n",
+    "                val_eo_loss = total_eo_val_loss / num_val_updates_captured\n",
     "\n",
     "                if \"train_size\" not in training_config and \"val_size\" not in training_config:\n",
     "                    training_config[\"train_size\"] = train_size\n",
@@ -861,12 +898,8 @@
     "                        wandb.config.update(training_config)\n",
     "\n",
     "                to_log = {\n",
-    "                    \"train_loss\": train_loss,\n",
-    "                    \"val_loss\": val_loss,\n",
     "                    \"train_eo_loss\": train_eo_loss,\n",
     "                    \"val_eo_loss\": val_eo_loss,\n",
-    "                    \"train_dynamic_world_loss\": train_dw_loss,\n",
-    "                    \"val_dynamic_world_loss\": val_dw_loss,\n",
     "                    \"training_step\": training_step,\n",
     "                    \"epoch\": epoch,\n",
     "                    \"lr\": lr,\n",
@@ -885,11 +918,7 @@
     "                    torch.save(model.state_dict(), best_model_path)\n",
     "\n",
     "                # reset training logging\n",
-    "                total_train_loss = 0.0\n",
     "                total_eo_train_loss = 0.0\n",
-    "                total_dw_train_loss = 0.0\n",
-    "                total_num_eo_values_masked = 0\n",
-    "                total_num_dw_values_masked = 0\n",
     "                num_updates_being_captured = 0\n",
     "                train_size = 0\n",
     "                num_validations += 1\n",
@@ -909,7 +938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "598452c3-59d9-44b5-9373-0647cb4fd5d8",
+   "id": "fa1dd8f5",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -917,9 +946,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "worldcereal",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "worldcereal"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -931,7 +960,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/presto_pretrain_finetune.ipynb
+++ b/notebooks/presto_pretrain_finetune.ipynb
@@ -30,12 +30,9 @@
    "source": [
     "import json\n",
     "import logging\n",
-    "import os\n",
-    "import warnings\n",
     "from pathlib import Path\n",
-    "from typing import List, Tuple, cast\n",
-    "import pandas as pd\n",
     "\n",
+    "import pandas as pd\n",
     "import torch\n",
     "import torch.nn as nn\n",
     "from torch import optim\n",
@@ -43,8 +40,6 @@
     "\n",
     "from presto import Presto\n",
     "from presto.dataops import BANDS_GROUPS_IDX, MASK_STRATEGIES\n",
-    "\n",
-    "\n",
     "from presto.model import LossWrapper, adjust_learning_rate, param_groups_weight_decay\n",
     "from presto.utils import (\n",
     "    DEFAULT_SEED,\n",
@@ -53,7 +48,6 @@
     "    initialize_logging,\n",
     "    seed_everything,\n",
     "    timestamp_dirname,\n",
-    "    update_data_dir,\n",
     ")\n",
     "\n",
     "logger = logging.getLogger(\"__main__\")"
@@ -71,16 +65,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26-10-2023 11:20:42 - INFO - Initialized logging to output/2023_10_26_11_20_42_680240/console-output.log\n",
-      "26-10-2023 11:20:42 - INFO - Using output dir: output/2023_10_26_11_20_42_680240\n"
+      "26-10-2023 11:37:43 - INFO - Initialized logging to output/2023_10_26_11_37_43_147545/console-output.log\n",
+      "26-10-2023 11:37:43 - INFO - Using output dir: output/2023_10_26_11_37_43_147545\n"
      ]
     }
    ],
    "source": [
-    "model_name = 'presto_worldcereal'\n",
+    "model_name = \"presto_worldcereal\"\n",
     "seed = DEFAULT_SEED\n",
     "seed_everything(seed)\n",
-    "output_parent_dir = Path('.')\n",
+    "output_parent_dir = Path(\".\")\n",
     "run_id = None\n",
     "\n",
     "logging_dir = output_parent_dir / \"output\" / timestamp_dirname(run_id)\n",
@@ -96,7 +90,7 @@
     "min_learning_rate = 0\n",
     "warmup_epochs = 2\n",
     "weight_decay = 0.05\n",
-    "batch_size = 2  # default 4096\n",
+    "batch_size = 4096  # default 4096\n",
     "\n",
     "# Default mask strategies and mask_ratio\n",
     "mask_strategies = MASK_STRATEGIES\n",
@@ -368,7 +362,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26-10-2023 11:20:42 - INFO - Setting up dataloaders\n"
+      "26-10-2023 11:37:43 - INFO - Setting up dataloaders\n"
      ]
     }
    ],
@@ -407,14 +401,6 @@
     "tags": []
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "72\n",
-      "group_bands\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
@@ -580,7 +566,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "26-10-2023 11:20:43 - INFO - Setting up model\n"
+      "26-10-2023 11:37:43 - INFO - Setting up model\n"
      ]
     },
     {
@@ -734,79 +720,44 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "Epoch:   0%|                                                            | 0/20 [00:00<?, ?it/s]"
+      "Epoch:   0%|                                                            | 0/20 [00:00<?, ?it/s]\n",
+      "Train:   0%|                                                             | 0/1 [00:00<?, ?it/s]\u001b[A\n",
+      "Train: 100%|█████████████████████████████████████████████████████| 1/1 [00:11<00:00, 11.32s/it]\u001b[A\n",
+      "Epoch:   5%|██▌                                                 | 1/20 [00:11<03:35, 11.34s/it]\u001b[A\n",
+      "Train:   0%|                                                             | 0/1 [00:00<?, ?it/s]\u001b[A\n",
+      "Epoch:   5%|██▌                                                 | 1/20 [00:15<04:48, 15.19s/it]\u001b[A\n"
      ]
     },
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Epoch: 0\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Train:   0%|                                                           | 0/250 [00:00<?, ?it/s]\u001b[A\n",
-      "Train:   0%|▏                                                  | 1/250 [00:00<00:28,  8.67it/s]\u001b[A"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "72\n",
-      "group_bands\n",
-      "72\n",
-      "group_bands\n",
-      "72\n",
-      "group_bands\n",
-      "72\n",
-      "random_timesteps\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "Epoch:   0%|                                                            | 0/20 [00:00<?, ?it/s]\u001b[A"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "72\n",
-      "group_bands\n",
-      "72\n",
-      "chunk_timesteps\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "ename": "AssertionError",
-     "evalue": "10752, 9856",
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[8], line 30\u001b[0m\n\u001b[1;32m     21\u001b[0m lr \u001b[38;5;241m=\u001b[39m adjust_learning_rate(\n\u001b[1;32m     22\u001b[0m     optimizer,\n\u001b[1;32m     23\u001b[0m     epoch_step \u001b[38;5;241m/\u001b[39m dataloader_length \u001b[38;5;241m+\u001b[39m epoch,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     27\u001b[0m     min_learning_rate,\n\u001b[1;32m     28\u001b[0m )\n\u001b[1;32m     29\u001b[0m \u001b[38;5;66;03m# Get model outputs and calculate loss\u001b[39;00m\n\u001b[0;32m---> 30\u001b[0m y_pred, dw_pred \u001b[38;5;241m=\u001b[39m \u001b[43mmodel\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     31\u001b[0m \u001b[43m    \u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmask\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mdynamic_world\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mx_dw\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mlatlons\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlatlons\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmonth\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mstart_month\u001b[49m\n\u001b[1;32m     32\u001b[0m \u001b[43m\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     33\u001b[0m \u001b[38;5;66;03m# set all SRTM timesteps except the first one to unmasked, so that\u001b[39;00m\n\u001b[1;32m     34\u001b[0m \u001b[38;5;66;03m# they will get ignored by the loss function even if the SRTM\u001b[39;00m\n\u001b[1;32m     35\u001b[0m \u001b[38;5;66;03m# value was masked\u001b[39;00m\n\u001b[1;32m     36\u001b[0m mask[:, \u001b[38;5;241m1\u001b[39m:, BANDS_GROUPS_IDX[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mSRTM\u001b[39m\u001b[38;5;124m\"\u001b[39m]] \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;01mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/nn/modules/module.py:1501\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1496\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1497\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1498\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1499\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1500\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1501\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1502\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1503\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/Documents/code/presto/presto/presto.py:729\u001b[0m, in \u001b[0;36mPresto.forward\u001b[0;34m(self, x, dynamic_world, latlons, mask, month)\u001b[0m\n\u001b[1;32m    721\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mforward\u001b[39m(\n\u001b[1;32m    722\u001b[0m     \u001b[38;5;28mself\u001b[39m,\n\u001b[1;32m    723\u001b[0m     x: torch\u001b[38;5;241m.\u001b[39mTensor,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    727\u001b[0m     month: Union[torch\u001b[38;5;241m.\u001b[39mTensor, \u001b[38;5;28mint\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m0\u001b[39m,\n\u001b[1;32m    728\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m torch\u001b[38;5;241m.\u001b[39mTensor:\n\u001b[0;32m--> 729\u001b[0m     x, kept_indices, removed_indices \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mencoder\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m    730\u001b[0m \u001b[43m        \u001b[49m\u001b[43mx\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    731\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdynamic_world\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mdynamic_world\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    732\u001b[0m \u001b[43m        \u001b[49m\u001b[43mlatlons\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mlatlons\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    733\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmask\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmask\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    734\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmonth\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mmonth\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m    735\u001b[0m \u001b[43m        \u001b[49m\u001b[43meval_task\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mFalse\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m    736\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    738\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdecoder(x, kept_indices, removed_indices, month)\n",
-      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/nn/modules/module.py:1501\u001b[0m, in \u001b[0;36mModule._call_impl\u001b[0;34m(self, *args, **kwargs)\u001b[0m\n\u001b[1;32m   1496\u001b[0m \u001b[38;5;66;03m# If we don't have any hooks, we want to skip the rest of the logic in\u001b[39;00m\n\u001b[1;32m   1497\u001b[0m \u001b[38;5;66;03m# this function, and just call forward.\u001b[39;00m\n\u001b[1;32m   1498\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m (\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_forward_pre_hooks\n\u001b[1;32m   1499\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_backward_pre_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_backward_hooks\n\u001b[1;32m   1500\u001b[0m         \u001b[38;5;129;01mor\u001b[39;00m _global_forward_hooks \u001b[38;5;129;01mor\u001b[39;00m _global_forward_pre_hooks):\n\u001b[0;32m-> 1501\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mforward_call\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43margs\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1502\u001b[0m \u001b[38;5;66;03m# Do not call functions when jit is used\u001b[39;00m\n\u001b[1;32m   1503\u001b[0m full_backward_hooks, non_full_backward_hooks \u001b[38;5;241m=\u001b[39m [], []\n",
-      "File \u001b[0;32m~/Documents/code/presto/presto/presto.py:468\u001b[0m, in \u001b[0;36mEncoder.forward\u001b[0;34m(self, x, dynamic_world, latlons, mask, month, eval_task)\u001b[0m\n\u001b[1;32m    466\u001b[0m x \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mcat(all_tokens, dim\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)  \u001b[38;5;66;03m# [batch, timesteps, embedding_dim]\u001b[39;00m\n\u001b[1;32m    467\u001b[0m mask \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mcat(all_masks, dim\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m1\u001b[39m)  \u001b[38;5;66;03m# [batch, timesteps, embedding_dim]\u001b[39;00m\n\u001b[0;32m--> 468\u001b[0m x, kept_indices, removed_indices \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmask_tokens\u001b[49m\u001b[43m(\u001b[49m\u001b[43mx\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mmask\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    470\u001b[0m \u001b[38;5;66;03m# append latlon tokens\u001b[39;00m\n\u001b[1;32m    471\u001b[0m latlon_tokens \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mlatlon_embed(\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mcartesian(latlons))\u001b[38;5;241m.\u001b[39munsqueeze(\u001b[38;5;241m1\u001b[39m)\n",
-      "File \u001b[0;32m~/Documents/code/presto/presto/presto.py:373\u001b[0m, in \u001b[0;36mEncoder.mask_tokens\u001b[0;34m(x, mask)\u001b[0m\n\u001b[1;32m    368\u001b[0m \u001b[38;5;129m@staticmethod\u001b[39m\n\u001b[1;32m    369\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mmask_tokens\u001b[39m(x, mask):\n\u001b[1;32m    370\u001b[0m     summed \u001b[38;5;241m=\u001b[39m mask\u001b[38;5;241m.\u001b[39msum(\n\u001b[1;32m    371\u001b[0m         dim\u001b[38;5;241m=\u001b[39m(\u001b[38;5;241m1\u001b[39m, \u001b[38;5;241m2\u001b[39m)\n\u001b[1;32m    372\u001b[0m     )  \u001b[38;5;66;03m# summed tells me the number of masked elements per batch idx\u001b[39;00m\n\u001b[0;32m--> 373\u001b[0m     \u001b[38;5;28;01massert\u001b[39;00m summed\u001b[38;5;241m.\u001b[39mmax() \u001b[38;5;241m==\u001b[39m summed\u001b[38;5;241m.\u001b[39mmin(), \u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;132;01m{\u001b[39;00msummed\u001b[38;5;241m.\u001b[39mmax()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m, \u001b[39m\u001b[38;5;132;01m{\u001b[39;00msummed\u001b[38;5;241m.\u001b[39mmin()\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m    375\u001b[0m     batch_size \u001b[38;5;241m=\u001b[39m x\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m    376\u001b[0m     removed_elements_per_batch \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mint\u001b[39m(summed\u001b[38;5;241m.\u001b[39mmax() \u001b[38;5;241m/\u001b[39m mask\u001b[38;5;241m.\u001b[39mshape[\u001b[38;5;241m2\u001b[39m])\n",
-      "\u001b[0;31mAssertionError\u001b[0m: 10752, 9856"
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 14\u001b[0m\n\u001b[1;32m     12\u001b[0m train_size \u001b[38;5;241m=\u001b[39m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m     13\u001b[0m model\u001b[38;5;241m.\u001b[39mtrain()\n\u001b[0;32m---> 14\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m epoch_step, b \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28menumerate\u001b[39m(tqdm(train_dataloader, desc\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mTrain\u001b[39m\u001b[38;5;124m\"\u001b[39m, leave\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m)):\n\u001b[1;32m     15\u001b[0m     mask, x, y, start_month \u001b[38;5;241m=\u001b[39m b[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mto(device), b[\u001b[38;5;241m2\u001b[39m]\u001b[38;5;241m.\u001b[39mto(device), b[\u001b[38;5;241m3\u001b[39m]\u001b[38;5;241m.\u001b[39mto(device), b[\u001b[38;5;241m6\u001b[39m]\n\u001b[1;32m     16\u001b[0m     dw_mask, x_dw, y_dw \u001b[38;5;241m=\u001b[39m b[\u001b[38;5;241m1\u001b[39m]\u001b[38;5;241m.\u001b[39mto(device), b[\u001b[38;5;241m4\u001b[39m]\u001b[38;5;241m.\u001b[39mto(device)\u001b[38;5;241m.\u001b[39mlong(), b[\u001b[38;5;241m5\u001b[39m]\u001b[38;5;241m.\u001b[39mto(device)\u001b[38;5;241m.\u001b[39mlong()\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/tqdm/std.py:1195\u001b[0m, in \u001b[0;36mtqdm.__iter__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1192\u001b[0m time \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_time\n\u001b[1;32m   1194\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m-> 1195\u001b[0m     \u001b[38;5;28;01mfor\u001b[39;00m obj \u001b[38;5;129;01min\u001b[39;00m iterable:\n\u001b[1;32m   1196\u001b[0m         \u001b[38;5;28;01myield\u001b[39;00m obj\n\u001b[1;32m   1197\u001b[0m         \u001b[38;5;66;03m# Update and possibly print the progressbar.\u001b[39;00m\n\u001b[1;32m   1198\u001b[0m         \u001b[38;5;66;03m# Note: does not call self.update(1) for speed optimisation.\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/utils/data/dataloader.py:633\u001b[0m, in \u001b[0;36m_BaseDataLoaderIter.__next__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    630\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_sampler_iter \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[1;32m    631\u001b[0m     \u001b[38;5;66;03m# TODO(https://github.com/pytorch/pytorch/issues/76750)\u001b[39;00m\n\u001b[1;32m    632\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_reset()  \u001b[38;5;66;03m# type: ignore[call-arg]\u001b[39;00m\n\u001b[0;32m--> 633\u001b[0m data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_next_data\u001b[49m\u001b[43m(\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    634\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_num_yielded \u001b[38;5;241m+\u001b[39m\u001b[38;5;241m=\u001b[39m \u001b[38;5;241m1\u001b[39m\n\u001b[1;32m    635\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_dataset_kind \u001b[38;5;241m==\u001b[39m _DatasetKind\u001b[38;5;241m.\u001b[39mIterable \u001b[38;5;129;01mand\u001b[39;00m \\\n\u001b[1;32m    636\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_IterableDataset_len_called \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m \u001b[38;5;129;01mand\u001b[39;00m \\\n\u001b[1;32m    637\u001b[0m         \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_num_yielded \u001b[38;5;241m>\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_IterableDataset_len_called:\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/utils/data/dataloader.py:677\u001b[0m, in \u001b[0;36m_SingleProcessDataLoaderIter._next_data\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    675\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_next_data\u001b[39m(\u001b[38;5;28mself\u001b[39m):\n\u001b[1;32m    676\u001b[0m     index \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_next_index()  \u001b[38;5;66;03m# may raise StopIteration\u001b[39;00m\n\u001b[0;32m--> 677\u001b[0m     data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_dataset_fetcher\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mfetch\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindex\u001b[49m\u001b[43m)\u001b[49m  \u001b[38;5;66;03m# may raise StopIteration\u001b[39;00m\n\u001b[1;32m    678\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_pin_memory:\n\u001b[1;32m    679\u001b[0m         data \u001b[38;5;241m=\u001b[39m _utils\u001b[38;5;241m.\u001b[39mpin_memory\u001b[38;5;241m.\u001b[39mpin_memory(data, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_pin_memory_device)\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py:51\u001b[0m, in \u001b[0;36m_MapDatasetFetcher.fetch\u001b[0;34m(self, possibly_batched_index)\u001b[0m\n\u001b[1;32m     49\u001b[0m         data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset\u001b[38;5;241m.\u001b[39m__getitems__(possibly_batched_index)\n\u001b[1;32m     50\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m---> 51\u001b[0m         data \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[idx] \u001b[38;5;28;01mfor\u001b[39;00m idx \u001b[38;5;129;01min\u001b[39;00m possibly_batched_index]\n\u001b[1;32m     52\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m     53\u001b[0m     data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[possibly_batched_index]\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/torch/utils/data/_utils/fetch.py:51\u001b[0m, in \u001b[0;36m<listcomp>\u001b[0;34m(.0)\u001b[0m\n\u001b[1;32m     49\u001b[0m         data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset\u001b[38;5;241m.\u001b[39m__getitems__(possibly_batched_index)\n\u001b[1;32m     50\u001b[0m     \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m---> 51\u001b[0m         data \u001b[38;5;241m=\u001b[39m [\u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdataset\u001b[49m\u001b[43m[\u001b[49m\u001b[43midx\u001b[49m\u001b[43m]\u001b[49m \u001b[38;5;28;01mfor\u001b[39;00m idx \u001b[38;5;129;01min\u001b[39;00m possibly_batched_index]\n\u001b[1;32m     52\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[1;32m     53\u001b[0m     data \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdataset[possibly_batched_index]\n",
+      "File \u001b[0;32m~/Documents/code/presto/notebooks/ewoc_presto.py:139\u001b[0m, in \u001b[0;36mWorldCerealDataset.__getitem__\u001b[0;34m(self, idx)\u001b[0m\n\u001b[1;32m    136\u001b[0m row \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdf\u001b[38;5;241m.\u001b[39miloc[idx, :]\n\u001b[1;32m    138\u001b[0m \u001b[38;5;66;03m# Convert inputs and return\u001b[39;00m\n\u001b[0;32m--> 139\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mconvert_inputs\u001b[49m\u001b[43m(\u001b[49m\u001b[43mrow\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/Documents/code/presto/notebooks/ewoc_presto.py:182\u001b[0m, in \u001b[0;36mWorldCerealDataset.convert_inputs\u001b[0;34m(self, row)\u001b[0m\n\u001b[1;32m    180\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m b \u001b[38;5;129;01min\u001b[39;00m s2_band_mapping\u001b[38;5;241m.\u001b[39mkeys():\n\u001b[1;32m    181\u001b[0m     fts \u001b[38;5;241m=\u001b[39m [x \u001b[38;5;28;01mfor\u001b[39;00m x \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mdf\u001b[38;5;241m.\u001b[39mcolumns \u001b[38;5;28;01mif\u001b[39;00m b \u001b[38;5;129;01min\u001b[39;00m x \u001b[38;5;129;01mand\u001b[39;00m \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mts\u001b[39m\u001b[38;5;124m\"\u001b[39m \u001b[38;5;129;01min\u001b[39;00m x]\n\u001b[0;32m--> 182\u001b[0m     single_sample[b] \u001b[38;5;241m=\u001b[39m \u001b[43mrow\u001b[49m\u001b[43m[\u001b[49m\u001b[43mfts\u001b[49m\u001b[43m]\u001b[49m\u001b[38;5;241m.\u001b[39mvalues\u001b[38;5;241m.\u001b[39mastype(\u001b[38;5;28mint\u001b[39m)\n\u001b[1;32m    184\u001b[0m s2_data \u001b[38;5;241m=\u001b[39m torch\u001b[38;5;241m.\u001b[39mfrom_numpy(single_sample\u001b[38;5;241m.\u001b[39mvalues)\u001b[38;5;241m.\u001b[39mfloat()\n\u001b[1;32m    186\u001b[0m \u001b[38;5;66;03m# Sentinel-1\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/series.py:966\u001b[0m, in \u001b[0;36mSeries.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    963\u001b[0m     key \u001b[38;5;241m=\u001b[39m np\u001b[38;5;241m.\u001b[39masarray(key, dtype\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mbool\u001b[39m)\n\u001b[1;32m    964\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_get_values(key)\n\u001b[0;32m--> 966\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_with\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/series.py:1006\u001b[0m, in \u001b[0;36mSeries._get_with\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   1003\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39miloc[key]\n\u001b[1;32m   1005\u001b[0m \u001b[38;5;66;03m# handle the dup indexing case GH#4246\u001b[39;00m\n\u001b[0;32m-> 1006\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mloc\u001b[49m\u001b[43m[\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m]\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexing.py:931\u001b[0m, in \u001b[0;36m_LocationIndexer.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m    928\u001b[0m axis \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39maxis \u001b[38;5;129;01mor\u001b[39;00m \u001b[38;5;241m0\u001b[39m\n\u001b[1;32m    930\u001b[0m maybe_callable \u001b[38;5;241m=\u001b[39m com\u001b[38;5;241m.\u001b[39mapply_if_callable(key, \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mobj)\n\u001b[0;32m--> 931\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_getitem_axis\u001b[49m\u001b[43m(\u001b[49m\u001b[43mmaybe_callable\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexing.py:1153\u001b[0m, in \u001b[0;36m_LocIndexer._getitem_axis\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1150\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mhasattr\u001b[39m(key, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mndim\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;129;01mand\u001b[39;00m key\u001b[38;5;241m.\u001b[39mndim \u001b[38;5;241m>\u001b[39m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m   1151\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mCannot index with multidimensional key\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n\u001b[0;32m-> 1153\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_getitem_iterable\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1155\u001b[0m \u001b[38;5;66;03m# nested tuple slicing\u001b[39;00m\n\u001b[1;32m   1156\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m is_nested_tuple(key, labels):\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexing.py:1093\u001b[0m, in \u001b[0;36m_LocIndexer._getitem_iterable\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1090\u001b[0m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_validate_key(key, axis)\n\u001b[1;32m   1092\u001b[0m \u001b[38;5;66;03m# A collection of keys\u001b[39;00m\n\u001b[0;32m-> 1093\u001b[0m keyarr, indexer \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_get_listlike_indexer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkey\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43maxis\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1094\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mobj\u001b[38;5;241m.\u001b[39m_reindex_with_indexers(\n\u001b[1;32m   1095\u001b[0m     {axis: [keyarr, indexer]}, copy\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m, allow_dups\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mTrue\u001b[39;00m\n\u001b[1;32m   1096\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexing.py:1309\u001b[0m, in \u001b[0;36m_LocIndexer._get_listlike_indexer\u001b[0;34m(self, key, axis)\u001b[0m\n\u001b[1;32m   1306\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m ax[indexer], indexer\n\u001b[1;32m   1308\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m ax\u001b[38;5;241m.\u001b[39m_index_as_unique:\n\u001b[0;32m-> 1309\u001b[0m     indexer \u001b[38;5;241m=\u001b[39m \u001b[43max\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_indexer_for\u001b[49m\u001b[43m(\u001b[49m\u001b[43mkeyarr\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   1310\u001b[0m     keyarr \u001b[38;5;241m=\u001b[39m ax\u001b[38;5;241m.\u001b[39mreindex(keyarr)[\u001b[38;5;241m0\u001b[39m]\n\u001b[1;32m   1311\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexes/base.py:5275\u001b[0m, in \u001b[0;36mIndex.get_indexer_for\u001b[0;34m(self, target, **kwargs)\u001b[0m\n\u001b[1;32m   5263\u001b[0m \u001b[38;5;250m\u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   5264\u001b[0m \u001b[38;5;124;03mGuaranteed return of an indexer even when non-unique.\u001b[39;00m\n\u001b[1;32m   5265\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   5272\u001b[0m \u001b[38;5;124;03m    List of indices.\u001b[39;00m\n\u001b[1;32m   5273\u001b[0m \u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   5274\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_index_as_unique:\n\u001b[0;32m-> 5275\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mget_indexer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtarget\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[38;5;241;43m*\u001b[39;49m\u001b[43mkwargs\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   5276\u001b[0m indexer, _ \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mget_indexer_non_unique(target)\n\u001b[1;32m   5277\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m indexer\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexes/base.py:3437\u001b[0m, in \u001b[0;36mIndex.get_indexer\u001b[0;34m(self, target, method, limit, tolerance)\u001b[0m\n\u001b[1;32m   3426\u001b[0m \u001b[38;5;129m@Appender\u001b[39m(_index_shared_docs[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mget_indexer\u001b[39m\u001b[38;5;124m\"\u001b[39m] \u001b[38;5;241m%\u001b[39m _index_doc_kwargs)\n\u001b[1;32m   3427\u001b[0m \u001b[38;5;129m@final\u001b[39m\n\u001b[1;32m   3428\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mget_indexer\u001b[39m(\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   3434\u001b[0m ) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m np\u001b[38;5;241m.\u001b[39mndarray:\n\u001b[1;32m   3435\u001b[0m     \u001b[38;5;66;03m# returned ndarray is np.intp\u001b[39;00m\n\u001b[1;32m   3436\u001b[0m     method \u001b[38;5;241m=\u001b[39m missing\u001b[38;5;241m.\u001b[39mclean_reindex_fill_method(method)\n\u001b[0;32m-> 3437\u001b[0m     target \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43m_maybe_cast_listlike_indexer\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtarget\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   3439\u001b[0m     \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_check_indexing_method(method, limit, tolerance)\n\u001b[1;32m   3441\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_index_as_unique:\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexes/base.py:5708\u001b[0m, in \u001b[0;36mIndex._maybe_cast_listlike_indexer\u001b[0;34m(self, target)\u001b[0m\n\u001b[1;32m   5704\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_maybe_cast_listlike_indexer\u001b[39m(\u001b[38;5;28mself\u001b[39m, target) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Index:\n\u001b[1;32m   5705\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   5706\u001b[0m \u001b[38;5;124;03m    Analogue to maybe_cast_indexer for get_indexer instead of get_loc.\u001b[39;00m\n\u001b[1;32m   5707\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 5708\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mensure_index\u001b[49m\u001b[43m(\u001b[49m\u001b[43mtarget\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexes/base.py:6336\u001b[0m, in \u001b[0;36mensure_index\u001b[0;34m(index_like, copy)\u001b[0m\n\u001b[1;32m   6333\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m Index(index_like, copy\u001b[38;5;241m=\u001b[39mcopy, tupleize_cols\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mFalse\u001b[39;00m)\n\u001b[1;32m   6334\u001b[0m \u001b[38;5;28;01melse\u001b[39;00m:\n\u001b[0;32m-> 6336\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[43mIndex\u001b[49m\u001b[43m(\u001b[49m\u001b[43mindex_like\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mcopy\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mcopy\u001b[49m\u001b[43m)\u001b[49m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexes/base.py:462\u001b[0m, in \u001b[0;36mIndex.__new__\u001b[0;34m(cls, data, dtype, copy, name, tupleize_cols, **kwargs)\u001b[0m\n\u001b[1;32m    459\u001b[0m arr \u001b[38;5;241m=\u001b[39m com\u001b[38;5;241m.\u001b[39masarray_tuplesafe(data, dtype\u001b[38;5;241m=\u001b[39mnp\u001b[38;5;241m.\u001b[39mdtype(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mobject\u001b[39m\u001b[38;5;124m\"\u001b[39m))\n\u001b[1;32m    461\u001b[0m \u001b[38;5;28;01mif\u001b[39;00m dtype \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[0;32m--> 462\u001b[0m     arr \u001b[38;5;241m=\u001b[39m \u001b[43m_maybe_cast_data_without_dtype\u001b[49m\u001b[43m(\u001b[49m\u001b[43marr\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m    463\u001b[0m     dtype \u001b[38;5;241m=\u001b[39m arr\u001b[38;5;241m.\u001b[39mdtype\n\u001b[1;32m    465\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m kwargs:\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/core/indexes/base.py:6411\u001b[0m, in \u001b[0;36m_maybe_cast_data_without_dtype\u001b[0;34m(subarr)\u001b[0m\n\u001b[1;32m   6397\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_maybe_cast_data_without_dtype\u001b[39m(subarr: np\u001b[38;5;241m.\u001b[39mndarray) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m ArrayLike:\n\u001b[1;32m   6398\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m   6399\u001b[0m \u001b[38;5;124;03m    If we have an arraylike input but no passed dtype, try to infer\u001b[39;00m\n\u001b[1;32m   6400\u001b[0m \u001b[38;5;124;03m    a supported dtype.\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   6408\u001b[0m \u001b[38;5;124;03m    np.ndarray or ExtensionArray\u001b[39;00m\n\u001b[1;32m   6409\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[0;32m-> 6411\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[43mlib\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mmaybe_convert_objects\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m   6412\u001b[0m \u001b[43m        \u001b[49m\u001b[43msubarr\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   6413\u001b[0m \u001b[43m        \u001b[49m\u001b[43mconvert_datetime\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m   6414\u001b[0m \u001b[43m        \u001b[49m\u001b[43mconvert_timedelta\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m   6415\u001b[0m \u001b[43m        \u001b[49m\u001b[43mconvert_period\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m   6416\u001b[0m \u001b[43m        \u001b[49m\u001b[43mconvert_interval\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;28;43;01mTrue\u001b[39;49;00m\u001b[43m,\u001b[49m\n\u001b[1;32m   6417\u001b[0m \u001b[43m        \u001b[49m\u001b[43mdtype_if_all_nat\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mnp\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mdtype\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mdatetime64[ns]\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m   6418\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m   6419\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m result\u001b[38;5;241m.\u001b[39mdtype\u001b[38;5;241m.\u001b[39mkind \u001b[38;5;129;01min\u001b[39;00m [\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mb\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mc\u001b[39m\u001b[38;5;124m\"\u001b[39m]:\n\u001b[1;32m   6420\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m subarr\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/pandas/_libs/lib.pyx:2451\u001b[0m, in \u001b[0;36mpandas._libs.lib.maybe_convert_objects\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/anaconda3/envs/lem/lib/python3.9/site-packages/numpy/core/numeric.py:289\u001b[0m, in \u001b[0;36mfull\u001b[0;34m(shape, fill_value, dtype, order, like)\u001b[0m\n\u001b[1;32m    285\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21m_full_dispatcher\u001b[39m(shape, fill_value, dtype\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, order\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, \u001b[38;5;241m*\u001b[39m, like\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    286\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m(like,)\n\u001b[0;32m--> 289\u001b[0m \u001b[38;5;129m@set_array_function_like_doc\u001b[39m\n\u001b[1;32m    290\u001b[0m \u001b[38;5;129m@set_module\u001b[39m(\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mnumpy\u001b[39m\u001b[38;5;124m'\u001b[39m)\n\u001b[1;32m    291\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m \u001b[38;5;21mfull\u001b[39m(shape, fill_value, dtype\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m, order\u001b[38;5;241m=\u001b[39m\u001b[38;5;124m'\u001b[39m\u001b[38;5;124mC\u001b[39m\u001b[38;5;124m'\u001b[39m, \u001b[38;5;241m*\u001b[39m, like\u001b[38;5;241m=\u001b[39m\u001b[38;5;28;01mNone\u001b[39;00m):\n\u001b[1;32m    292\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"\u001b[39;00m\n\u001b[1;32m    293\u001b[0m \u001b[38;5;124;03m    Return a new array of given shape and type, filled with `fill_value`.\u001b[39;00m\n\u001b[1;32m    294\u001b[0m \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    335\u001b[0m \n\u001b[1;32m    336\u001b[0m \u001b[38;5;124;03m    \"\"\"\u001b[39;00m\n\u001b[1;32m    337\u001b[0m     \u001b[38;5;28;01mif\u001b[39;00m like \u001b[38;5;129;01mis\u001b[39;00m \u001b[38;5;129;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n",
+      "\u001b[0;31mKeyboardInterrupt\u001b[0m: "
      ]
     }
    ],
@@ -819,7 +770,6 @@
     "\n",
     "with tqdm(range(num_epochs), desc=\"Epoch\") as tqdm_epoch:\n",
     "    for epoch in tqdm_epoch:\n",
-    "        print(f\"Epoch: {epoch}\")\n",
     "        # ------------------------ Training ----------------------------------------\n",
     "        total_eo_train_loss = 0.0\n",
     "        num_updates_being_captured = 0\n",
@@ -894,8 +844,8 @@
     "                if \"train_size\" not in training_config and \"val_size\" not in training_config:\n",
     "                    training_config[\"train_size\"] = train_size\n",
     "                    training_config[\"val_size\"] = val_size\n",
-    "                    if wandb_enabled:\n",
-    "                        wandb.config.update(training_config)\n",
+    "                    # if wandb_enabled:\n",
+    "                    #     wandb.config.update(training_config)\n",
     "\n",
     "                to_log = {\n",
     "                    \"train_eo_loss\": train_eo_loss,\n",
@@ -904,10 +854,10 @@
     "                    \"epoch\": epoch,\n",
     "                    \"lr\": lr,\n",
     "                }\n",
-    "                tqdm_epoch.set_postfix(loss=val_loss)\n",
+    "                tqdm_epoch.set_postfix(loss=val_eo_loss)\n",
     "\n",
-    "                if lowest_validation_loss is None or val_loss < lowest_validation_loss:\n",
-    "                    lowest_validation_loss = val_loss\n",
+    "                if lowest_validation_loss is None or val_eo_loss < lowest_validation_loss:\n",
+    "                    lowest_validation_loss = val_eo_loss\n",
     "                    best_val_epoch = epoch\n",
     "\n",
     "                    model_path = logging_dir / Path(\"models\")\n",
@@ -934,14 +884,6 @@
     "\n",
     "logger.info(f\"Done training, best model saved to {best_model_path}\")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fa1dd8f5",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
Update masking function to correctly calculate how many tokens should be masked when dynamic world is entirely masked.

The issue was that `make_mask` tries to make sure the same number of tokens are masked in each batch. However, in this new case Dynamic World is always masked (this occurs when we set all the Dynamic World values to `9`).

So the `make_mask` function was counting dynamic world tokens as potentially unmasked, but since they were always masked this was triggering the assert statement in the Presto model. 

This PR updates the `make_mask` function to ignore dynamic world entirely. It also updates the train script to remove any loss on the dynamic world output.

I can successfully run `ewoc_train_script.py` locally, with a batch size of 4096.